### PR TITLE
JAVA-1697-Added Dummy Values for Twilio Credentials

### DIFF
--- a/m12-lesson3-new/src/main/resources/application.properties
+++ b/m12-lesson3-new/src/main/resources/application.properties
@@ -5,10 +5,10 @@ server.tomcat.basedir=target/tomcat
 
 server.port=8081
 
-#twilio
-twilio.sid=AC02da72e747be6295a6daeeaccac3be85
-twilio.token=48c8279137cfaaf5998dc3bf8d38cb86
-twilio.sender=2017787046
+#twilio - update these credentials
+twilio.sid=AC00000000000000000000000000000000
+twilio.token=00000000000000000000000000000000
+twilio.sender=11111111111
 
 # Hibernate
 spring.jpa.hibernate.ddl-auto: update

--- a/m12-lesson3/pom.xml
+++ b/m12-lesson3/pom.xml
@@ -74,6 +74,12 @@ Module  12 - Lesson 3</description>
             <artifactId>jackson-databind</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+        </dependency>
+
         <!-- persistence -->
 
         <dependency>

--- a/m12-lesson3/pom.xml
+++ b/m12-lesson3/pom.xml
@@ -74,12 +74,6 @@ Module  12 - Lesson 3</description>
             <artifactId>jackson-databind</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.1</version>
-        </dependency>
-
         <!-- persistence -->
 
         <dependency>

--- a/m12-lesson3/src/main/resources/application.properties
+++ b/m12-lesson3/src/main/resources/application.properties
@@ -5,10 +5,10 @@ server.tomcat.basedir: target/tomcat
 
 server.port=8081
 
-#twilio
-twilio.sid=AC02da72e747be6295a6daeeaccac3be85
-twilio.token=48c8279137cfaaf5998dc3bf8d38cb86
-twilio.sender=2017787046
+#twilio - update these credentials
+twilio.sid=AC00000000000000000000000000000000
+twilio.token=00000000000000000000000000000000
+twilio.sender=11111111111
 
 # Hibernate
 spring.jpa.hibernate.ddl-auto: update


### PR DESCRIPTION
Added Dummy Values for Twilio Credentials in learn-spring-security-m12-l3-new and learn-spring-security-m12-l3 projects. These values would have to be replaced by proper credentials for the application to run without any errors.

With the dummy values, the tests pass and the build succeeds. However, if you do not replace these values, there will be a runtime exception once Twilio API is invoked to send out the confirmation SMS.

However the learn-spring-security-m12-l3 project isn't printing out the SMS  confirmation code to the console like the learn-spring-security-m12-l3-new  project so the app doesn't get past the code confirmation page. I hope this is by design.  