### PR TITLE
JAVA-1697-Added Dummy Values for Twilio Credentials

### DIFF
--- a/m12-lesson3-new/src/main/resources/application.properties
+++ b/m12-lesson3-new/src/main/resources/application.properties
@@ -5,10 +5,10 @@ server.tomcat.basedir=target/tomcat
 
 server.port=8081
 
-#twilio
-twilio.sid=AC55c117b24fed4e2a54149f587f8e20b6
-twilio.token=00601c8507d28bac5624a5d07f3941fd
-twilio.sender=18452500923
+#twilio - update these credentials
+twilio.sid=AC00000000000000000000000000000000
+twilio.token=00000000000000000000000000000000
+twilio.sender=11111111111
 
 # Hibernate
 spring.jpa.hibernate.ddl-auto: update

--- a/m12-lesson3/src/main/resources/application.properties
+++ b/m12-lesson3/src/main/resources/application.properties
@@ -5,10 +5,10 @@ server.tomcat.basedir=target/tomcat
 
 server.port=8081
 
-#twilio
-twilio.sid=AC55c117b24fed4e2a54149f587f8e20b6
-twilio.token=00601c8507d28bac5624a5d07f3941fd
-twilio.sender=18452500923
+#twilio - update these credentials
+twilio.sid=AC00000000000000000000000000000000
+twilio.token=00000000000000000000000000000000
+twilio.sender=11111111111
 
 # Hibernate
 spring.jpa.hibernate.ddl-auto: update


### PR DESCRIPTION
Added Dummy Values for Twilio Credentials in m14-lesson3 and m14-lesson3-new projects. These values would have to be replaced by proper credentials for the application to run without any errors.
With the dummy values, the tests pass and the build succeeds. However, if you do not replace these values, there will be a runtime exception once Twilio API is invoked to send out the confirmation SMS.